### PR TITLE
[fix]: Empty FormType fields producing SQL queries

### DIFF
--- a/Form/ChoiceList/ORMQueryBuilderLoader.php
+++ b/Form/ChoiceList/ORMQueryBuilderLoader.php
@@ -75,7 +75,7 @@ class ORMQueryBuilderLoader implements EntityLoaderInterface
         } else {
             $parameterType = Connection::PARAM_STR_ARRAY;
         }
-        if (!$values) {
+        if (!$values || count(array_filter($values)) == 0) {
             return array();
         }
 


### PR DESCRIPTION
Entity FormType fields when empty(field=null|'') are generating neccessary SQL queries and produces exceptions.

Info: http://tinyurl.com/julzhn5
