### PR TITLE
Field mapping unique is optional

### DIFF
--- a/Validator/DoctrineLoader.php
+++ b/Validator/DoctrineLoader.php
@@ -68,7 +68,7 @@ final class DoctrineLoader implements LoaderInterface
 
         // Type and nullable aren't handled here, use the PropertyInfo Loader instead.
         foreach ($doctrineMetadata->fieldMappings as $mapping) {
-            if (true === $mapping['unique'] && !isset($existingUniqueFields[$mapping['fieldName']])) {
+            if (true === ($mapping['unique'] ?? false) && !isset($existingUniqueFields[$mapping['fieldName']])) {
                 $metadata->addConstraint(new UniqueEntity(['fields' => $mapping['fieldName']]));
             }
 


### PR DESCRIPTION
If array index is not set - use default `false` 

Error exception:
```
Executed script cache:clear  [KO]
 [KO]
Script cache:clear returned with error code 1
!!  
!!   // Clearing the cache for the dev environment with debug                       
!!   // true                                                                        
!!  
!!  
In DoctrineLoader.php line 71:
                                   
  [ErrorException]                 
  Notice: Undefined index: unique  
                                   

Exception trace:
 () at /home/ksaveras/Projects/mokytojas.local/vendor/symfony/doctrine-bridge/Validator/DoctrineLoader.php:71
 Symfony\Bridge\Doctrine\Validator\DoctrineLoader->loadClassMetadata() at /home/ksaveras/Projects/mokytojas.local/vendor/symfony/validator/Mapping/Loader/LoaderChain.php:54
 Symfony\Component\Validator\Mapping\Loader\LoaderChain->loadClassMetadata() at /home/ksaveras/Projects/mokytojas.local/vendor/symfony/validator/Mapping/Factory/LazyLoadingMetadataFactory.php:105
 Symfony\Component\Validator\Mapping\Factory\LazyLoadingMetadataFactory->getMetadataFor() at /home/ksaveras/Projects/mokytojas.local/vendor/symfony/framework-bundle/CacheWarmer/ValidatorCacheWarmer.php:63
 Symfony\Bundle\FrameworkBundle\CacheWarmer\ValidatorCacheWarmer->doWarmUp() at /home/ksaveras/Projects/mokytojas.local/vendor/symfony/framework-bundle/CacheWarmer/AbstractPhpFileCacheWarmer.php:51
 Symfony\Bundle\FrameworkBundle\CacheWarmer\AbstractPhpFileCacheWarmer->warmUp() at /home/ksaveras/Projects/mokytojas.local/vendor/symfony/http-kernel/CacheWarmer/CacheWarmerAggregate.php:96
 Symfony\Component\HttpKernel\CacheWarmer\CacheWarmerAggregate->warmUp() at /home/ksaveras/Projects/mokytojas.local/vendor/symfony/framework-bundle/Command/CacheClearCommand.php:194
 Symfony\Bundle\FrameworkBundle\Command\CacheClearCommand->warmup() at /home/ksaveras/Projects/mokytojas.local/vendor/symfony/framework-bundle/Command/CacheClearCommand.php:129
 Symfony\Bundle\FrameworkBundle\Command\CacheClearCommand->execute() at /home/ksaveras/Projects/mokytojas.local/vendor/symfony/console/Command/Command.php:255
 Symfony\Component\Console\Command\Command->run() at /home/ksaveras/Projects/mokytojas.local/vendor/symfony/console/Application.php:930
 Symfony\Component\Console\Application->doRunCommand() at /home/ksaveras/Projects/mokytojas.local/vendor/symfony/framework-bundle/Console/Application.php:87
 Symfony\Bundle\FrameworkBundle\Console\Application->doRunCommand() at /home/ksaveras/Projects/mokytojas.local/vendor/symfony/console/Application.php:273
 Symfony\Component\Console\Application->doRun() at /home/ksaveras/Projects/mokytojas.local/vendor/symfony/framework-bundle/Console/Application.php:73
 Symfony\Bundle\FrameworkBundle\Console\Application->doRun() at /home/ksaveras/Projects/mokytojas.local/vendor/symfony/console/Application.php:149
 Symfony\Component\Console\Application->run() at /home/ksaveras/Projects/mokytojas.local/bin/console:40

cache:clear [--no-warmup] [--no-optional-warmers] [-h|--help] [-q|--quiet] [-v|vv|vvv|--verbose] [-V|--version] [--ansi] [--no-ansi] [-n|--no-interaction] [-e|--env ENV] [--no-debug] [--] <command>

./bin/console ca:cl     
```