### PR TITLE
Add 'attribute' to allowed mapping config types

### DIFF
--- a/DependencyInjection/AbstractDoctrineExtension.php
+++ b/DependencyInjection/AbstractDoctrineExtension.php
@@ -227,7 +227,7 @@ abstract class AbstractDoctrineExtension extends Extension
             throw new \InvalidArgumentException(sprintf('Specified non-existing directory "%s" as Doctrine mapping source.', $mappingConfig['dir']));
         }
 
-        if (!\in_array($mappingConfig['type'], ['xml', 'yml', 'annotation', 'php', 'staticphp'])) {
+        if (!\in_array($mappingConfig['type'], ['xml', 'yml', 'annotation', 'php', 'staticphp', 'attribute'])) {
             throw new \InvalidArgumentException(sprintf('Can only configure "xml", "yml", "annotation", "php" or "staticphp" through the DoctrineBundle. Use your own bundle to configure other metadata drivers. You can register them by adding a new driver to the "%s" service definition.', $this->getObjectManagerElementName($objectManagerName.'_metadata_driver')));
         }
     }

--- a/DependencyInjection/AbstractDoctrineExtension.php
+++ b/DependencyInjection/AbstractDoctrineExtension.php
@@ -228,7 +228,7 @@ abstract class AbstractDoctrineExtension extends Extension
         }
 
         if (!\in_array($mappingConfig['type'], ['xml', 'yml', 'annotation', 'php', 'staticphp', 'attribute'])) {
-            throw new \InvalidArgumentException(sprintf('Can only configure "xml", "yml", "annotation", "php" or "staticphp" through the DoctrineBundle. Use your own bundle to configure other metadata drivers. You can register them by adding a new driver to the "%s" service definition.', $this->getObjectManagerElementName($objectManagerName.'_metadata_driver')));
+            throw new \InvalidArgumentException(sprintf('Can only configure "xml", "yml", "annotation", "php" or "staticphp", "attribute" through the DoctrineBundle. Use your own bundle to configure other metadata drivers. You can register them by adding a new driver to the "%s" service definition.', $this->getObjectManagerElementName($objectManagerName.'_metadata_driver')));
         }
     }
 


### PR DESCRIPTION
Hi! Recently https://github.com/doctrine/orm/pull/8266 was merged in. I had made a new symfony project and wanted to use the entity attributes to generate a schema, I was able to do so but needed to allow setting a type of "attribute" in my doctrine orm mappings type configuration by changing this class 
(and adding the corresponding parameter for the attributes driver to DoctrineBundle (https://github.com/doctrine/DoctrineBundle/pull/1313)

I am not sure if this is useful, sorry if it is not! (I am not sure which branch this should go to, because I guess this relies on doctrine/orm 2.9.x)

thanks for all the code by the way!