### PR TITLE
prevent doctrine deprecation for fieldmapping

### DIFF
--- a/Form/DoctrineOrmTypeGuesser.php
+++ b/Form/DoctrineOrmTypeGuesser.php
@@ -129,8 +129,8 @@ class DoctrineOrmTypeGuesser implements FormTypeGuesserInterface
         if ($ret && isset($ret[0]->fieldMappings[$property]) && !$ret[0]->hasAssociation($property)) {
             $mapping = $ret[0]->getFieldMapping($property);
 
-            if (isset($mapping['length'])) {
-                return new ValueGuess($mapping['length'], Guess::HIGH_CONFIDENCE);
+            if (isset($mapping->length)) {
+                return new ValueGuess($mapping->length, Guess::HIGH_CONFIDENCE);
             }
 
             if (\in_array($ret[0]->getTypeOfField($property), [Types::DECIMAL, Types::FLOAT])) {


### PR DESCRIPTION
prevent this deprecation : 
User Deprecated: Using ArrayAccess on Doctrine\ORM\Mapping\FieldMapping is deprecated and will not be possible in Doctrine ORM 4.0. Use the corresponding property instead. (ArrayAccessImplementation.php:18 called by DoctrineOrmTypeGuesser.php:132, https://github.com/doctrine/orm/pull/11211, package doctrine/orm)