### PR TITLE
Add primary key to schema_subscriber_check

### DIFF
--- a/SchemaListener/AbstractSchemaListener.php
+++ b/SchemaListener/AbstractSchemaListener.php
@@ -23,7 +23,7 @@ abstract class AbstractSchemaListener
     {
         return static function (\Closure $exec) use ($connection): bool {
             $checkTable = 'schema_subscriber_check_'.bin2hex(random_bytes(7));
-            $connection->executeStatement(sprintf('CREATE TABLE %s (id INTEGER NOT NULL)', $checkTable));
+            $connection->executeStatement(sprintf('CREATE TABLE %s (id INTEGER PRIMARY KEY NOT NULL)', $checkTable));
 
             try {
                 $exec(sprintf('DROP TABLE %s', $checkTable));


### PR DESCRIPTION
Add a primary key to allow using the listener when  'sql_require_primary_key'  is set.

In Digital Ocean this variable is set on all clusters. After upgrading from 6.2 to 6.3 it was no longer possible to use the doctrine schema commands. 